### PR TITLE
 #162094246 Implement change order location route

### DIFF
--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -74,7 +74,8 @@ class OrderController {
       weightMetric VARCHAR(255) NOT NULL,
       sentOn TIMESTAMPTZ DEFAULT now() NOT NULL,
       deliveredOn TIMESTAMPTZ DEFAULT now() NOT NULL,
-      status VARCHAR(20) DEFAULT 'placed' NOT NULL,
+      present_location VARCHAR(255) DEFAULT 'Not available' NOT NULL,
+      status VARCHAR(20) DEFAULT 'Placed' NOT NULL,
       pickupLocation VARCHAR(255) NOT NULL,
       destination VARCHAR(255) NOT NULL,
       receiversEmail VARCHAR(100) NOT NULL
@@ -158,6 +159,28 @@ class OrderController {
         parcel_id: result.rows[0].parcel_id,
         status: result.rows[0].status,
         message: 'Parcel status updated',
+      }];
+      res.status(200).json({
+        data,
+      });
+    }).catch((error) => {
+      res.status(422).json({
+        message: 'Error processing your request',
+        error,
+      });
+    });
+  }
+
+  static changeLocation(req, res) {
+    const { parcelId } = req.params;
+    const { present_location } = req.body;
+    const sql = 'UPDATE parcels SET present_location = $1 WHERE parcel_id = $2 RETURNING parcel_id, present_location';
+    const params = [present_location, parcelId];
+    return client.query(sql, params).then((result) => {
+      const data = [{
+        parcel_id: result.rows[0].parcel_id,
+        status: result.rows[0].present_location,
+        message: 'Parcel location updated',
       }];
       res.status(200).json({
         data,

--- a/server/routes/parcelDeliveryOrders.js
+++ b/server/routes/parcelDeliveryOrders.js
@@ -20,5 +20,6 @@ router.put('/parcels/:parcelId/cancel', checkParcelId, orderController.cancelPar
 router.post('/parcels', orderController.createParcelDeliveryOrder);
 router.put('/parcels/:parcelId/destination', orderController.changeParcelDestination);
 router.put('/parcels/:parcelId/status', orderController.changeOrderStatus);
+router.put('/parcels/:parcelId/presentLocation', orderController.changeLocation);
 
 export default router;


### PR DESCRIPTION
**What does this PR do?**
implement change order present location route

**Description of task to be completed**
query database and update the location field of the specific parcelId

**How should this be manually tested?**
Clone the project, run "npm install" to install all dependencies, run "npm run start:dev" to execute the entry point file, the server should be running on port 5000. Using postman, input the new location field, navigate to localhost:5000/parcels/:parcelId/presentLocation to change the present location of an order..

**Any background context you want to provide?**
none

what are the relevant pivotal tracker stories?
 #162094246